### PR TITLE
Allow immediate resolution upon Deferred instantiation

### DIFF
--- a/promise.coffee
+++ b/promise.coffee
@@ -120,12 +120,14 @@ class Promise
 		@then = ( onFulfilled, onRejected ) -> resolver.then( onFulfilled, onRejected )
 
 class Deferred
-	constructor: ->
+	constructor: (resolveValue) ->
 		resolver = new Resolver()
 		
 		@promise = resolver.promise
 		@resolve = ( value ) -> resolver.resolve( value )
 		@reject = ( error ) -> resolver.reject( error )
+		
+		if typeof resolveValue isnt 'undefined' then @resolve resolveValue
 
 target = exports ? window
 target.Deferred = Deferred


### PR DESCRIPTION
Allows simplifying patterns like so:

``` coffeescript
cachedValue = null
foo = ->
  if cachedValue?
    return (new Deferred cachedValue).promise
  d = new Deferred
  $.get('/some/slow/process').done( (data) ->
    cachedValue = data
    d.resolve data
  )
  return d.promise
foo() # Slow running
foo() # Cached value returned
```
